### PR TITLE
Add new tests for tag filters

### DIFF
--- a/gherkin_objects/tag_filter.py
+++ b/gherkin_objects/tag_filter.py
@@ -30,7 +30,7 @@ class GherkinTagFilter:
 
         # No adjacent tags
         tag_pattern = r'@\S+'
-        match = re.search(rf'{tag_pattern}\s*{tag_pattern}', expression)
+        match = re.search(rf'{tag_pattern}[()\s]*{tag_pattern}', expression)
         if match:
             raise ValueError(
                 f'Adjacent tags with no operator: {match.group(0)}')
@@ -47,6 +47,10 @@ class GherkinTagFilter:
                 count += 1
             if char == ')':
                 count -= 1
+            if count < 0:
+                raise ValueError(f'Unbalanced parentheses: Unexpected closing parenthesis at char {i} in tag expression:'
+                                 f'\n{expression}'
+                                 f'\n{" " * (i)}^')
         if count != 0:
             raise ValueError(f'Unbalanced parentheses: {expression}')
 

--- a/tests/test_tag_filter/test_gherkin_tag_filter.py
+++ b/tests/test_tag_filter/test_gherkin_tag_filter.py
@@ -161,7 +161,30 @@ class GherkinTagFilterExceptionTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             GherkinTagFilter(input).evaluate([])
 
+    def test_unbalanced_parentheses___unclosed_open(self):
+        input = '(@tag1 and @tag2'
+        with self.assertRaises(ValueError):
+            GherkinTagFilter(input)
 
+    def test_unbalanced_parentheses___extra_close(self):
+        input = '(@tag1 and @tag2))'
+        with self.assertRaises(ValueError):
+            GherkinTagFilter(input)
+
+    def test_unbalanced_parentheses___wrong_order(self):
+        input = '@tag1) and @tag2('
+        with self.assertRaises(ValueError):
+            GherkinTagFilter(input)
+
+    def test_adjacent_tags(self):
+        input = '@tag1 @tag2'
+        with self.assertRaises(ValueError):
+            GherkinTagFilter(input)
+
+    def test_adjacent_tags___in_parens(self):
+        input = '(@tag1)(@tag2)'
+        with self.assertRaises(ValueError):
+            GherkinTagFilter(input)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Code coverage revealed several untested portions of tag filter logic.  Added tests, and discovered and corrected two additional error modes that snuck through validation.